### PR TITLE
Support TS-specific AST generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@4.13.0",
   "name": "i18next-cli-plugin-svelte",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "i18next-cli plugin to extract Javascript/Typescript from Svelte components",
   "keywords": [
     "i18next",

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -417,6 +417,81 @@ console.log("World!");
 				expected: {
 					key_attr: "Default Attr"
 				}
+			},
+			{
+				name: "unwraps TS-specific wrappers (as, !, types)",
+				source: `
+					<script lang="ts">
+						const { t } = getContext();
+						const a = t('key-as' as any, 'Default As');
+						const b = t('key-non-null'!, 'Default Non-Null');
+						const c = t(<string>'key-assert', 'Default Assertion');
+					</script>
+				`,
+				expected: {
+					"key-as": "Default As",
+					"key-non-null": "Default Non-Null",
+					"key-assert": "Default Assertion"
+				}
+			},
+			{
+				name: "skips TS metadata (interfaces, types, generics)",
+				source: `
+					<script lang="ts">
+						import { t } from "i18next";
+
+						interface User<T extends string> {
+							name: T;
+							role: 'admin' | 'guest';
+						}
+
+						type Handler = (id: number) => void;
+						const msg = t<string>('generic-key', 'Generic Default');
+					</script>
+				`,
+				expected: {
+					"generic-key": "Generic Default"
+				}
+			},
+			{
+				name: "extracts from TS Enums (if used as values)",
+				source: `
+					<script lang="ts">
+						import { t } from "i18next";
+						enum Status {
+							Active = t('status-active', 'Active'),
+							Pending = t('status-pending', 'Pending')
+						}
+					</script>
+				`,
+				expected: {
+					"status-active": "Active",
+					"status-pending": "Pending"
+				}
+			},
+			{
+				// https://github.com/dreamscached/i18next-cli-plugin-svelte/issues/10
+				name: "pr#10 specific case (TS interface)",
+				source: `
+					<script lang="ts">
+						import { getTranslationContext } from '@codeggs/translation-context';
+
+						interface Props {
+							id: string;
+						}
+
+						const { t } = $derived.by(getTranslationContext('ui-form'));
+
+						const { id  }: Props = $props();
+					</script>
+
+					<div {id}>
+						{t('hello-world', 'hello world!')}
+					</div>
+				`,
+				expected: {
+					"hello-world": "hello world!"
+				}
 			}
 		])("$name", async ({ source, expected }) => {
 			await writeFile(join(tempDir, "src/App.svelte"), source);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { generate } from "astring";
+import { generate, GENERATOR } from "astring";
 import { walk } from "estree-walker";
 import type { Plugin, PluginContext } from "i18next-cli";
 import { parse, type AST } from "svelte/compiler";
+
+type AstGenerator = typeof GENERATOR;
 
 /**
  * Enables I18next to extract translation keys from .svelte component files.
@@ -10,6 +12,48 @@ import { parse, type AST } from "svelte/compiler";
 export class I18nextPluginSvelte implements Plugin {
 	/** i18next-cli plugin name. */
 	public readonly name = "i18next-cli-plugin-svelte";
+	private readonly generator = this.createTypescriptAstGenerator();
+
+	/**
+	 * Creates a new AST generator to process Typescript specific syntax.
+	 * @returns an extended astree's {@link GENERATOR} object.
+	 */
+	private createTypescriptAstGenerator(): AstGenerator {
+		return new Proxy(
+			{
+				...GENERATOR,
+				TSAsExpression(node, state) {
+					// unwrap 'x as y'
+					this[node.expression.type]?.(node.expression, state);
+				},
+				TSNonNullExpression(node, state) {
+					// unwrap 'x!!'
+					this[node.expression.type]?.(node.expression, state);
+				},
+				TSTypeAssertion(node, state) {
+					// unwrap '<y> x'
+					this[node.expression.type]?.(node.expression, state);
+				},
+				TSInstantiationExpression(node, state) {
+					// unwrap 'const/let x: y = ...'
+					this[node.expression.type]?.(node.expression, state);
+				},
+				TSModuleBlock(node, state) {
+					// pass children inside 'declare module {...}'
+					for (const statement of node.body) {
+						this[statement.type]?.(statement, state);
+					}
+				}
+			},
+			{
+				/** Catch-all to ignore any TS-prefixed AST nodes if undefined. */
+				get(target: AstGenerator, prop: string) {
+					if (!(prop in target) && prop.startsWith("TS")) return () => {};
+					return target[prop];
+				}
+			}
+		);
+	}
 
 	/**
 	 * Extracts JS code from Svelte component `<script>` or `<script module>`,
@@ -50,13 +94,34 @@ export class I18nextPluginSvelte implements Plugin {
 			});
 		}
 
+		// This handles rare case when translated strings are
+		// used as enum value initializers
+		for (let i = extractedBody.length - 1; i >= 0; i--) {
+			const thisNode = extractedBody[i];
+			if (thisNode.type === "TSEnumDeclaration") {
+				extractedBody.splice(i, 1);
+				walk(thisNode, {
+					enter(node: any) {
+						if (node.type === "TSEnumMember") {
+							extractedBody.push(node.initializer);
+						}
+					}
+				});
+			}
+		}
+
 		// When contatenating make sure we don't cause issues with ASI
 		// Cast to any to satisfy astring's strict Node typing
-		return generate({
-			type: "Program",
-			body: extractedBody,
-			sourceType: "module"
-		} as any);
+		return generate(
+			{
+				type: "Program",
+				body: extractedBody,
+				sourceType: "module"
+			} as any,
+			{
+				generator: this.generator
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
This addresses #10 by extending `astring` code generator to properly handle typescript-specific syntax (by effectively just stripping it)