### PR TITLE
Extract JS code from Svelte to a properly scoped AST

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.0",
     "vitest": "^4.1.5"
+  },
+  "dependencies": {
+    "recast": "^0.23.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "README.md",
     "LICENSE"
   ],
+  "dependencies": {
+    "recast": "^0.23.11"
+  },
   "peerDependencies": {
     "estree-walker": "^3.0.3",
     "i18next-cli": "^1.51.6",
@@ -50,6 +53,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "@types/estree": "^1.0.8",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "4.1.5",
     "eslint": "^10.2.1",
@@ -61,8 +65,5 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.0",
     "vitest": "^4.1.5"
-  },
-  "dependencies": {
-    "recast": "^0.23.11"
   }
 }

--- a/src/ast.test.ts
+++ b/src/ast.test.ts
@@ -1,130 +1,163 @@
-import { describe, expect, it } from "vitest";
-import { extractScriptIIFE } from "./ast.js";
-import { parse, type AST } from "svelte/compiler";
 import * as recast from "recast";
+import { parse, type AST } from "svelte/compiler";
+import { describe, expect, it } from "vitest";
+
+import { extractScriptIIFE } from "./ast.js";
 
 describe("extractScriptIIFE", () => {
-    it.each([
-        {
-            source: `
+	it.each([
+		{
+			source: `
                 <script>
                     import { foobar } from "foobar";
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     const {
         foobar
     } = await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     import {} from "foobar";
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     import { foobar as barbaz } from "foobar";
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     const {
         foobar: barbaz
     } = await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     import { foobar as barbaz, bar } from "foobar";
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     const {
         foobar: barbaz,
         bar
     } = await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     import Foobar from "foobar";
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     const {
         default: Foobar
     } = await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     import Foobar, { foobar } from "foobar";
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     const {
         default: Foobar,
         foobar
     } = await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     import "foobar";
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     import * as foobar from "foobar";
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     const foobar = await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     const foobar = await import("foobar");
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     const foobar = await import("foobar");
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 <script>
                     if (true) {
                         const foobar = await import("foobar");
                     }
                 </script>
             `,
-            output: `(async () => {
+			output: `(async () => {
     if (true) {
         const foobar = await import("foobar");
     }
 })();`
-        }
-    ])("should convert import declarations to const declarations", ({ source, output }) => {
-        const ast = parse(source) as AST.Root;
-        const iife = extractScriptIIFE(ast.instance!);
-        const js = recast.print(iife).code;
-        expect(js).toEqual(output);
-    });
+		},
+		{
+			source: `
+                <script>
+                    export const foobar = 42;
+                </script>
+            `,
+			output: `(async () => {
+    const foobar = 42;
+})();`
+		},
+		{
+			source: `
+                <script>
+                    const foobar = 42;
+                    export default foobar;
+                </script>
+            `,
+			output: `(async () => {
+    const foobar = 42;
+    foobar;
+})();`
+		},
+		{
+			source: `
+                <script>
+                    const foo = import.meta.foo;
+                </script>
+            `,
+			output: `(async () => {
+    const foo = {}.foo;
+})();`
+		}
+	])("should convert/strip iife-unsafe constructs", ({ source, output }) => {
+		const ast = parse(source) as AST.Root;
+		const iife = extractScriptIIFE(ast.instance!);
+		const js = recast.print(iife).code;
+		expect(js).toEqual(output);
+	});
 });

--- a/src/ast.test.ts
+++ b/src/ast.test.ts
@@ -2,7 +2,7 @@ import * as recast from "recast";
 import { parse, type AST } from "svelte/compiler";
 import { describe, expect, it } from "vitest";
 
-import { extractScriptIIFE } from "./ast.js";
+import { extractScriptIIFE, extractTemplateExpr as extractTemplateIIFE } from "./ast.js";
 
 describe("extractScriptIIFE", () => {
 	it.each([
@@ -160,4 +160,50 @@ describe("extractScriptIIFE", () => {
 		const js = recast.print(iife).code;
 		expect(js).toEqual(output);
 	});
+
+    it.each([
+        {
+            source: `
+                {#snippet foobar()}
+                {/snippet}
+            `,
+            output: `(async () => {
+    (async () => {})();
+})();`
+        },
+        {
+            source: `
+                {#snippet foobar(x, y=42, z=fn("bar"))}
+                {/snippet}
+            `,
+            output: `(async () => {
+    (async () => {
+        fn("bar");
+    })();
+})();`
+        },
+        {
+            source: `
+                {#snippet foobar(x, y=42, z=fn("bar"))}{/snippet}
+                {#snippet barbaz(x, y, z)}
+                    <div my-attr={fn("bar")}>
+                    </div>
+                {/snippet}
+            `,
+            output: `(async () => {
+    (async () => {
+        fn("bar");
+    })();
+
+    (async () => {
+        fn("bar");
+    })();
+})();`
+        }
+    ])("should convert snippet to iife", ({ source, output }) => {
+        const ast = parse(source) as AST.Root & { html: AST.Fragment };
+		const iife = extractTemplateIIFE(ast.html);
+		const js = recast.print(iife).code;
+		expect(js).toEqual(output);
+    });
 });

--- a/src/ast.test.ts
+++ b/src/ast.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { extractScriptIIFE } from "./ast.js";
+import { parse, type AST } from "svelte/compiler";
+import * as recast from "recast";
+
+describe("extractScriptIIFE", () => {
+    it.each([
+        {
+            source: `
+                <script>
+                    import { foobar } from "foobar";
+                </script>
+            `,
+            output: `(async () => {
+    const {
+        foobar
+    } = await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    import {} from "foobar";
+                </script>
+            `,
+            output: `(async () => {
+    await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    import { foobar as barbaz } from "foobar";
+                </script>
+            `,
+            output: `(async () => {
+    const {
+        foobar: barbaz
+    } = await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    import { foobar as barbaz, bar } from "foobar";
+                </script>
+            `,
+            output: `(async () => {
+    const {
+        foobar: barbaz,
+        bar
+    } = await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    import Foobar from "foobar";
+                </script>
+            `,
+            output: `(async () => {
+    const {
+        default: Foobar
+    } = await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    import Foobar, { foobar } from "foobar";
+                </script>
+            `,
+            output: `(async () => {
+    const {
+        default: Foobar,
+        foobar
+    } = await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    import "foobar";
+                </script>
+            `,
+            output: `(async () => {
+    await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    import * as foobar from "foobar";
+                </script>
+            `,
+            output: `(async () => {
+    const foobar = await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    const foobar = await import("foobar");
+                </script>
+            `,
+            output: `(async () => {
+    const foobar = await import("foobar");
+})();`
+        },
+        {
+            source: `
+                <script>
+                    if (true) {
+                        const foobar = await import("foobar");
+                    }
+                </script>
+            `,
+            output: `(async () => {
+    if (true) {
+        const foobar = await import("foobar");
+    }
+})();`
+        }
+    ])("should convert import declarations to const declarations", ({ source, output }) => {
+        const ast = parse(source) as AST.Root;
+        const iife = extractScriptIIFE(ast.instance!);
+        const js = recast.print(iife).code;
+        expect(js).toEqual(output);
+    });
+});

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -3,7 +3,13 @@ import type * as estree from "estree";
 import { walk } from "estree-walker";
 import { type AST } from "svelte/compiler";
 
-export function extractScriptIIFE(script: AST.Script): estree.ExpressionStatement {
+/**
+ * Rewrites a Svelte `<script>` AST into IIFE-safe statements: top-level
+ * `import`/`export`/`import.meta` constructs are converted to forms that are
+ * legal inside a function body. The returned statements are *not* wrapped — use
+ * {@link toIIFE} (or {@link extractScriptIIFE}) to do that.
+ */
+export function extractScriptStatements(script: AST.Script): estree.Statement[] {
 	// We can't have top-level 'import ...' declaration in IIFE, so we
 	// need to convert them to 'const {} = await import' first.
 	walk(script as any, {
@@ -23,13 +29,18 @@ export function extractScriptIIFE(script: AST.Script): estree.ExpressionStatemen
 		}
 	});
 
-	return toIIFE(script.content.body as unknown as estree.Statement[]);
+	return script.content.body as unknown as estree.Statement[];
 }
 
-export function extractTemplateExpr(html: AST.Fragment): estree.ExpressionStatement[] {
+/**
+ * Collects the JS expressions embedded in a Svelte template fragment (mustache
+ * tags, logic blocks, attribute/snippet expressions) as statements. Snippets
+ * are converted to their own nested IIFEs so their parameter scope is honoured.
+ */
+export function extractTemplateStatements(fragment: AST.Fragment): estree.ExpressionStatement[] {
 	const statements: estree.ExpressionStatement[] = [];
 
-	walk(html as any, {
+	walk(fragment as any, {
 		// @ts-expect-error we're walking Svelte AST here
 		enter(node: AST.BaseNode) {
 			switch (node.type) {
@@ -48,12 +59,23 @@ export function extractTemplateExpr(html: AST.Fragment): estree.ExpressionStatem
 						expression: (node as any).expression
 					});
 					break;
-				// TODO: snippet
+				case "SnippetBlock":
+					statements.push(transformSnippet(node as AST.SnippetBlock));
+					this.remove();
+					break;
 			}
 		}
 	});
 
 	return statements;
+}
+
+export function extractScriptIIFE(script: AST.Script): estree.ExpressionStatement {
+	return toIIFE(extractScriptStatements(script));
+}
+
+export function extractTemplateExpr(fragment: AST.Fragment): estree.ExpressionStatement {
+	return toIIFE(extractTemplateStatements(fragment));
 }
 
 function transformImport(
@@ -137,7 +159,7 @@ function transformImport(
 	};
 }
 
-function toIIFE(nodes: estree.Statement[]): estree.ExpressionStatement {
+export function toIIFE(nodes: estree.Statement[]): estree.ExpressionStatement {
 	return {
 		type: "ExpressionStatement",
 		expression: {
@@ -202,11 +224,27 @@ function transformExport(
 
 function transformImportMeta(node: estree.Node): estree.Node {
 	if (node.type === "MetaProperty" && node.meta.name === "import") {
-		// Replace with a dummy identifier or object
-		return {
-			type: "ObjectExpression",
-			properties: []
-		};
+		// Replace with a dummy object {}
+		return { type: "ObjectExpression", properties: [] };
 	}
 	return node;
+}
+
+function transformSnippet(snippet: AST.SnippetBlock): estree.ExpressionStatement {
+	const statements: estree.Statement[] = [];
+
+	walk(snippet as any, {
+		enter(node) {
+			switch (node.type) {
+				case "CallExpression":
+					statements.push({
+						type: "ExpressionStatement",
+						expression: node
+					});
+					break;
+			}
+		}
+	});
+
+	return toIIFE(statements);
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type * as estree from "estree";
 import { walk } from "estree-walker";
 import { type AST } from "svelte/compiler";
@@ -9,8 +8,17 @@ export function extractScriptIIFE(script: AST.Script): estree.ExpressionStatemen
 	// need to convert them to 'const {} = await import' first.
 	walk(script as any, {
 		enter(node) {
-			if (node.type === "ImportDeclaration") {
-				this.replace(toConstImport(node));
+			switch (node.type) {
+				case "ImportDeclaration":
+					this.replace(transformImport(node));
+					break;
+				case "MetaProperty":
+					this.replace(transformImportMeta(node));
+					break;
+				case "ExportNamedDeclaration":
+				case "ExportDefaultDeclaration":
+					this.replace(transformExport(node));
+					break;
 			}
 		}
 	});
@@ -18,13 +26,13 @@ export function extractScriptIIFE(script: AST.Script): estree.ExpressionStatemen
 	return toIIFE(script.content.body as unknown as estree.Statement[]);
 }
 
-export function extractTemplateIIFE(html: AST.Fragment): estree.ExpressionStatement {
-    const statements: estree.Statement[] = [];
+export function extractTemplateExpr(html: AST.Fragment): estree.ExpressionStatement[] {
+	const statements: estree.ExpressionStatement[] = [];
 
-    walk(html as any, {
+	walk(html as any, {
 		// @ts-expect-error we're walking Svelte AST here
-        enter(node: AST.BaseNode) {
-            switch (node.type) {
+		enter(node: AST.BaseNode) {
+			switch (node.type) {
 				case "MustacheTag":
 				case "RawMustacheTag":
 				case "HtmlTag":
@@ -40,14 +48,15 @@ export function extractTemplateIIFE(html: AST.Fragment): estree.ExpressionStatem
 						expression: (node as any).expression
 					});
 					break;
-            }
-        }
-    });
+				// TODO: snippet
+			}
+		}
+	});
 
-    return toIIFE(statements);
+	return statements;
 }
 
-function toConstImport(
+function transformImport(
 	node: estree.ImportDeclaration
 ): estree.VariableDeclaration | estree.ExpressionStatement {
 	// 'await' expression common for any imports
@@ -133,18 +142,71 @@ function toIIFE(nodes: estree.Statement[]): estree.ExpressionStatement {
 		type: "ExpressionStatement",
 		expression: {
 			type: "CallExpression",
+			arguments: [],
 			optional: false,
 			callee: {
 				type: "ArrowFunctionExpression",
+				params: [],
 				expression: false,
 				async: true,
-				params: [],
 				body: {
 					type: "BlockStatement",
 					body: nodes
 				}
-			},
-			arguments: []
+			}
 		}
 	};
+}
+
+function transformExport(
+	exportNode: estree.ExportNamedDeclaration | estree.ExportDefaultDeclaration
+): estree.Statement {
+	// Named exports: export const x = 1; export function f() {}
+	if (exportNode.type === "ExportNamedDeclaration") {
+		if (exportNode.declaration) {
+			// Simply return the declaration (const/let/var/function/class)
+			// The 'export' keyword is effectively stripped here.
+			return exportNode.declaration;
+		}
+
+		// Handle: export { x }; (references only, no logic to extract)
+		return { type: "EmptyStatement" };
+	}
+
+	// Default Exports: export default ...
+	const decl = exportNode.declaration;
+
+	// Handle Function/Class Declarations (which might be anonymous)
+	if (decl.type === "FunctionDeclaration" || decl.type === "ClassDeclaration") {
+		if (decl.id) {
+			return decl as estree.Statement;
+		}
+
+		// If anonymous, we convert to an expression to satisfy 'Statement' type
+		return {
+			type: "ExpressionStatement",
+			expression: {
+				...decl,
+				type: decl.type === "FunctionDeclaration" ? "FunctionExpression" : "ClassExpression"
+			} as estree.FunctionExpression | estree.ClassExpression
+		};
+	}
+
+	// Expressions: export default t('key'); or export default { a: t('b') };
+	// Wrap in an ExpressionStatement to keep it as a valid Statement in the IIFE body
+	return {
+		type: "ExpressionStatement",
+		expression: decl as estree.Expression
+	};
+}
+
+function transformImportMeta(node: estree.Node): estree.Node {
+	if (node.type === "MetaProperty" && node.meta.name === "import") {
+		// Replace with a dummy identifier or object
+		return {
+			type: "ObjectExpression",
+			properties: []
+		};
+	}
+	return node;
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import type * as estree from "estree";
+import { walk } from "estree-walker";
+import { type AST } from "svelte/compiler";
+
+export function extractScriptIIFE(script: AST.Script): estree.ExpressionStatement {
+	// We can't have top-level 'import ...' declaration in IIFE, so we
+	// need to convert them to 'const {} = await import' first.
+	walk(script as any, {
+		enter(node) {
+			if (node.type === "ImportDeclaration") {
+				this.replace(toConstImport(node));
+			}
+		}
+	});
+
+	return toIIFE(script.content.body as unknown as estree.Statement[]);
+}
+
+export function extractTemplateIIFE(html: AST.Fragment): estree.ExpressionStatement {
+    const statements: estree.Statement[] = [];
+
+    walk(html as any, {
+		// @ts-expect-error we're walking Svelte AST here
+        enter(node: AST.BaseNode) {
+            switch (node.type) {
+				case "MustacheTag":
+				case "RawMustacheTag":
+				case "HtmlTag":
+				case "RenderTag":
+				case "AttachTag":
+				case "ConstTag":
+				case "IfBlock":
+				case "EachBlock":
+				case "KeyBlock":
+				case "AwaitBlock":
+					statements.push({
+						type: "ExpressionStatement",
+						expression: (node as any).expression
+					});
+					break;
+            }
+        }
+    });
+
+    return toIIFE(statements);
+}
+
+function toConstImport(
+	node: estree.ImportDeclaration
+): estree.VariableDeclaration | estree.ExpressionStatement {
+	// 'await' expression common for any imports
+	const awaitExpression: estree.AwaitExpression = {
+		type: "AwaitExpression",
+		argument: {
+			type: "CallExpression",
+			callee: { type: "Import" as any },
+			arguments: [node.source],
+			optional: false
+		}
+	};
+
+	// Handle side-effect only imports: import "foobar";
+	if (node.specifiers.length === 0) {
+		return {
+			type: "ExpressionStatement",
+			expression: awaitExpression
+		};
+	}
+
+	// Handle namespace import: import * as Foobar
+	const namespaceSpecifier = node.specifiers.find((s) => s.type === "ImportNamespaceSpecifier");
+	let id: estree.Identifier | estree.ObjectPattern;
+
+	if (namespaceSpecifier) {
+		id = namespaceSpecifier.local;
+	} else {
+		// Handle named and default imports
+		const properties = node.specifiers
+			.map((specifier) => {
+				switch (specifier.type) {
+					case "ImportSpecifier":
+						return {
+							type: "Property" as const,
+							key: specifier.imported,
+							value: specifier.local,
+							kind: "init" as const,
+							shorthand:
+								specifier.imported.type === "Identifier" &&
+								specifier.imported.name === specifier.local.name,
+							method: false,
+							computed: false
+						};
+					case "ImportDefaultSpecifier":
+						return {
+							type: "Property" as const,
+							key: { type: "Identifier" as const, name: "default" },
+							value: specifier.local,
+							kind: "init" as const,
+							shorthand: false,
+							method: false,
+							computed: false
+						};
+					case "ImportNamespaceSpecifier":
+					default:
+						return null;
+				}
+			})
+			.filter((val) => val !== null);
+
+		id = {
+			type: "ObjectPattern",
+			properties: properties
+		};
+	}
+
+	return {
+		type: "VariableDeclaration",
+		kind: "const",
+		declarations: [
+			{
+				type: "VariableDeclarator",
+				id: id,
+				init: awaitExpression
+			}
+		]
+	};
+}
+
+function toIIFE(nodes: estree.Statement[]): estree.ExpressionStatement {
+	return {
+		type: "ExpressionStatement",
+		expression: {
+			type: "CallExpression",
+			optional: false,
+			callee: {
+				type: "ArrowFunctionExpression",
+				expression: false,
+				async: true,
+				params: [],
+				body: {
+					type: "BlockStatement",
+					body: nodes
+				}
+			},
+			arguments: []
+		}
+	};
+}

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 
 import { extract } from "i18next-cli";
 import type { I18nextToolkitConfig } from "i18next-cli";
-import { parse } from "svelte/compiler";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import I18nextSveltePlugin from "./index.js";
@@ -15,221 +14,191 @@ function pathEndsWith(p: string | undefined, suffix: string): boolean {
 }
 
 describe("I18nextSveltePlugin", () => {
-	describe("should extract valid js code", () => {
+	describe("onLoad", () => {
 		it.each([
-			{
-				name: "example Svelte component",
-				source: `
-				<script>
-					import i18n from "i18next-cli";
-					console.log(i18n.t("sample.translation.key"));
-				</script>
-
-				<div class="mydiv">Hello world!</div>
-
-				<style>
-					.mydiv {
-						color: black;
-					}
-				</style>
-				`,
-				expected: `
-					import i18n from "i18next-cli";
-					console.log(i18n.t("sample.translation.key"));
-				`
-			},
-			{
-				name: "one empty <script> tag",
-				source: `<script></script>`,
-				expected: ``
-			},
-			{
-				name: "empty file",
-				source: "",
-				expected: ``
-			},
-			{
-				name: "no <script> tag",
-				source: `<div>foobar</div><style>div{}</style>`,
-				expected: ``
-			},
-			{
-				name: "instance with a module <script> tag",
-				source: `
-				<script module>export const myval = 42;</script>
-				<script>console.log("Hello");</script>
-				`,
-				expected: `console.log("Hello");
-;export const myval = 42;`
-			},
-			{
-				name: "one empty <script module> tag",
-				source: `<script module>export const foobar = "bar";</script>`,
-				expected: `export const foobar = "bar";`
-			},
-			{
-				name: "multiple statements in <script> with no semicolons",
-				source: `<script>console.log("Hello")\nconsole.log("World!")</script>`,
-				expected: `console.log("Hello")
-console.log("World!")`
-			},
-			{
-				name: "asi-unsafe component with instance and module <script> tags",
-				source: `<script>
-const data = [1, 2, 3]
-</script>
-<script context="module">
-[4, 5, 6].forEach(n => console.log(n))
-</script>`,
-				expected: `
-const data = [1, 2, 3]
-
-;
-[4, 5, 6].forEach(n => console.log(n))
-`
-			}
-		])("$name", ({ source, expected }) => {
+			{ path: "test.ts", source: "<foobar> invalid svelte/ts code" },
+			{ path: "test.svelte.ts", source: "<foobar> invalid svelte/ts code" },
+			{ path: "svelte.ts", source: "<foobar> invalid svelte/ts code" }
+		])("returns undefined for non-svelte file $path", ({ path, source }) => {
 			const plugin = new I18nextSveltePlugin();
-			const extracted = plugin.onLoad!(source, "test.svelte") as string;
-			expect(() => parse(extracted)).not.toThrow();
-			expect(extracted).toEqual(expected);
+			expect(plugin.onLoad!(source, path)).toBeUndefined();
+		});
+
+		it.each([
+			{ name: "an example component", source: "<script>console.log('test')</script>" },
+			{ name: "an empty file", source: "" },
+			{ name: "a file with no <script> tag", source: "<div>foobar</div><style>div{}</style>" },
+			{ name: "an empty <script> tag", source: "<script></script>" },
+			{ name: "an empty <script module> tag", source: "<script module></script>" },
+			{
+				name: "instance and module scripts",
+				source: `<script module>export const myval = 42;</script><script>console.log("Hello");</script>`
+			}
+		])("returns a string for $name (.svelte)", ({ source }) => {
+			const plugin = new I18nextSveltePlugin();
+			expect(typeof plugin.onLoad!(source, "test.svelte")).toBe("string");
 		});
 	});
 
-	describe("should extract statement from mustache tag", () => {
-		it.each([
-			{
-				name: "text tag (i18next.t)",
-				source: "<div>{i18next.t('key1')}</div>",
-				expected: "(i18next.t('key1'))"
-			},
-			{
-				name: "attribute tag (i18next.t)",
-				source: "<button title={i18next.t('key2')}></button>",
-				expected: "(i18next.t('key2'))"
-			},
-			{
-				name: "text tag (t)",
-				source: "<div>{t('key1')}</div>",
-				expected: "(t('key1'))"
-			},
-			{
-				name: "attribute tag (t)",
-				source: "<button title={t('key2')}></button>",
-				expected: "(t('key2'))"
-			},
-			{
-				name: "non-key tag",
-				source: "<div>{variable}</div>",
-				expected: "(variable)"
-			},
-			{
-				name: "empty html",
-				source: "<script></script>",
-				expected: ""
-			}
-		])("$name", ({ source, expected }) => {
-			const plugin = new I18nextSveltePlugin();
-			const extracted = plugin.onLoad!(source, "test.svelte");
-			expect(extracted).toEqual(expected);
-		});
-	});
+	// The plugin only rewrites a component into JS that i18next-cli can parse;
+	// the actual contract is *which keys end up extracted*. These tests drive
+	// the full extract() pipeline so they stay meaningful regardless of the
+	// exact intermediate JS we emit.
+	describe("key extraction", () => {
+		let tempDir: string;
 
-	describe("should extract statements from svelte tags", () => {
+		beforeEach(async () => {
+			tempDir = await mkdtemp(join(tmpdir(), "i18next-svelte-key-extract-"));
+			await mkdir(join(tempDir, "src"), { recursive: true });
+		});
+
+		afterEach(async () => {
+			await rm(tempDir, { recursive: true, force: true });
+		});
+
+		function makeConfig(): I18nextToolkitConfig {
+			return {
+				locales: ["en"],
+				extract: {
+					input: [join(tempDir, "src/**/*.svelte")],
+					output: join(tempDir, "locales/{{language}}/{{namespace}}.json"),
+					functions: ["t", "i18next.t", "i18n.t"],
+					defaultNS: "translation",
+					useTranslationNames: ["useTranslation", "getTranslationContext"]
+				},
+				plugins: [new I18nextSveltePlugin()]
+			};
+		}
+
 		it.each([
 			{
-				name: "from {@html}",
-				source: "<div>{@html getHtmlWithTrans(t('key1'))}</div>",
-				expected: "(getHtmlWithTrans(t('key1')))"
+				name: "from <script>",
+				source: `
+					<script>
+						import { t } from "i18next";
+						const val = t('key_script', 'Default Script');
+					</script>
+				`,
+				expected: { key_script: "Default Script" }
 			},
 			{
-				name: "from {@render}",
-				source: "{@render snippetWithTrans(t('key1'))}",
-				expected: "(snippetWithTrans(t('key1')))"
+				name: "from <script module>",
+				source: `<script module>const v = t('key_module', 'Default Module');</script>`,
+				expected: { key_module: "Default Module" }
 			},
 			{
-				name: "from {@attach}",
-				source: "<div {@attach fnWithTrans(t('key1'))}></div>",
-				expected: "(fnWithTrans(t('key1')))"
+				name: "from both <script> and template",
+				source: `
+					<script>
+						import { t } from "i18next";
+						const val = t('key_script', 'Default Script');
+					</script>
+					<div>{t('key_html', 'Default HTML')}</div>
+				`,
+				expected: {
+					key_script: "Default Script",
+					key_html: "Default HTML"
+				}
 			},
 			{
-				name: "from {@const}",
-				source: "{@const foobar = t('key1')}",
-				expected: "(foobar = t('key1'))"
+				name: "from an attribute expression",
+				source: `
+					<script>import { t } from "i18next";</script>
+					<button title={t('key_attr', 'Default Attr')}></button>
+				`,
+				expected: { key_attr: "Default Attr" }
 			},
 			{
-				name: "from {#if} (no else-if)",
-				source: "{#if t('key1')}{/if}",
-				expected: "(t('key1'))"
+				name: "from a mustache tag (t)",
+				source: `<div>{t('key_text', 'Text')}</div>`,
+				expected: { key_text: "Text" }
 			},
 			{
-				name: "from {#if} (with else-if)",
-				source: "{#if t('key1')}{:else if t('key2')}{/if}",
-				expected: "(t('key1'))\n;(t('key2'))"
-			},
-			{
-				name: "from {#each}",
-				source: "{#each t('key1')}{/each}",
-				expected: "(t('key1'))"
-			},
-			{
-				name: "from {#key}",
-				source: "{#key t('key1')}{/key}",
-				expected: "(t('key1'))"
-			},
-			{
-				name: "from {#await}",
-				source: "{#await t('key1')}{/await}",
-				expected: "(t('key1'))"
-			},
-			{
-				name: "from {#snippet}",
-				source: "{#snippet foo(arg=t('key1'))}{/snippet}",
-				expected: "((arg=t('key1'));)"
+				name: "from a mustache tag (i18next.t)",
+				source: `<div>{i18next.t('key_member', 'Member')}</div>`,
+				expected: { key_member: "Member" }
 			},
 			{
 				// https://github.com/dreamscached/i18next-cli-plugin-svelte/issues/14
-				name: "from {#snippet}",
+				name: "from {@html}",
+				source: `<div>{@html getHtmlWithTrans(t('key_html_tag', 'Html Tag'))}</div>`,
+				expected: { key_html_tag: "Html Tag" }
+			},
+			{
+				name: "from {@render}",
+				source: `{@render snippetWithTrans(t('key_render', 'Render'))}`,
+				expected: { key_render: "Render" }
+			},
+			{
+				name: "from {@attach}",
+				source: `<div {@attach fnWithTrans(t('key_attach', 'Attach'))}></div>`,
+				expected: { key_attach: "Attach" }
+			},
+			{
+				name: "from {@const}",
+				source: `{#if true}{@const c = t('key_const', 'Const')}{c}{/if}`,
+				expected: { key_const: "Const" }
+			},
+			{
+				name: "from {#if}",
+				source: `{#if t('key_if', 'If')}{/if}`,
+				expected: { key_if: "If" }
+			},
+			{
+				name: "from {#if} else-if branch",
+				source: `{#if cond}{:else if t('key_elseif', 'ElseIf')}{/if}`,
+				expected: { key_elseif: "ElseIf" }
+			},
+			{
+				name: "from {#each}",
+				source: `{#each [t('key_each', 'Each')] as item}{item}{/each}`,
+				expected: { key_each: "Each" }
+			},
+			{
+				name: "from {#key}",
+				source: `{#key t('key_key', 'Key')}{/key}`,
+				expected: { key_key: "Key" }
+			},
+			{
+				name: "from {#await}",
+				source: `{#await t('key_await', 'Await')}{/await}`,
+				expected: { key_await: "Await" }
+			},
+			{
+				name: "from a {#snippet} parameter default",
+				source: `{#snippet foo(arg = t('key_snippet_param', 'Snippet Param'))}{/snippet}`,
+				expected: { key_snippet_param: "Snippet Param" }
+			},
+			{
+				// https://github.com/dreamscached/i18next-cli-plugin-svelte/issues/14
+				name: "from a {#snippet} body",
+				source: `{#snippet foo()}{t('key_snippet_body', 'Snippet Body')}{/snippet}`,
+				expected: { key_snippet_body: "Snippet Body" }
+			},
+			{
+				// https://github.com/dreamscached/i18next-cli-plugin-svelte/issues/10
+				name: "from typescript with an interface",
 				source: `
-					{#snippet hello(variable)}
-						{variable}
-					{/snippet}
-				`,
-				expected: "(variable)"
-			}
-		])("$name", ({ source, expected }) => {
-			const plugin = new I18nextSveltePlugin();
-			const extracted = plugin.onLoad!(source, "test.svelte");
-			expect(extracted).toEqual(expected);
-		});
-	});
+					<script lang="ts">
+						import { getTranslationContext } from './translation-context';
 
-	describe("should skip non-svelte files", () => {
-		it.each([
-			{
-				path: "test.svelte",
-				source: "<script>console.log('test')</script>",
-				expected: "console.log('test')"
-			},
-			{
-				path: "test.ts",
-				source: "<foobar> invalid svelte/ts code",
-				expected: undefined
-			},
-			{
-				path: "test.svelte.ts",
-				source: "<foobar> invalid svelte/ts code",
-				expected: undefined
-			},
-			{
-				path: "svelte.ts",
-				source: "<foobar> invalid svelte/ts code",
-				expected: undefined
+						interface Props {
+							id: string;
+						}
+
+						const { t } = $derived.by(getTranslationContext('translation'));
+						const { id }: Props = $props();
+					</script>
+					<div {id}>{t('key_ts', 'Hello TS')}</div>
+				`,
+				expected: { key_ts: "Hello TS" }
 			}
-		])("$path", ({ path, source, expected }) => {
-			const plugin = new I18nextSveltePlugin();
-			const extracted = plugin.onLoad!(source, path);
-			expect(extracted).toEqual(expected);
+		])("extracts keys $name", async ({ source, expected }) => {
+			await writeFile(join(tempDir, "src/App.svelte"), source);
+			const results = await extract(makeConfig());
+			const file = results.find((r) => pathEndsWith(r.path, "/en/translation.json"));
+			expect(file).toBeDefined();
+			expect(file!.newTranslations).toEqual(expected);
 		});
 	});
 
@@ -398,9 +367,7 @@ const data = [1, 2, 3]
 					</div>
 				`,
 				configOverrides: {
-					useTranslationNames: [
-						"getTranslationContext"
-					]
+					useTranslationNames: ["getTranslationContext"]
 				},
 				expectedNamespace: "/en/my-namespace.json",
 				expectedTranslations: {
@@ -417,9 +384,7 @@ const data = [1, 2, 3]
 					};
 				`,
 				configOverrides: {
-					useTranslationNames: [
-						"getTranslationContext"
-					]
+					useTranslationNames: ["getTranslationContext"]
 				},
 				expectedNamespace: "/en/my-namespace.json",
 				expectedTranslations: {
@@ -461,98 +426,5 @@ const data = [1, 2, 3]
 				}
 			}
 		);
-	});
-
-	describe("should extract translation keys from svelte components", () => {
-		let tempDir: string;
-
-		function pathEndsWith(p: string | undefined, suffix: string): boolean {
-			if (!p) return false;
-			return p.replace(/\\/g, "/").endsWith(suffix);
-		}
-
-		beforeEach(async () => {
-			tempDir = await mkdtemp(join(tmpdir(), "i18next-svelte-key-extract-"));
-			await mkdir(join(tempDir, "src"), { recursive: true });
-		});
-
-		afterEach(async () => {
-			await rm(tempDir, { recursive: true, force: true });
-		});
-
-		function makeConfig(): I18nextToolkitConfig {
-			return {
-				locales: ["en"],
-				extract: {
-					input: [join(tempDir, "src/**/*.svelte")],
-					output: join(tempDir, "locales/{{language}}/{{namespace}}.json"),
-					functions: ["t", "i18next.t"],
-					defaultNS: "translation",
-					useTranslationNames: ["useTranslation", "getTranslationContext"]
-				},
-				plugins: [new I18nextSveltePlugin()]
-			};
-		}
-
-		it.each([
-			{
-				name: "extracts simple keys from script and html",
-				source: `
-                    <script>
-						import { t } from "i18next";
-                        const val = t('key_script', 'Default Script');
-                    </script>
-                    <div>{t('key_html', 'Default HTML')}</div>
-                `,
-				path: "/en/translation.json",
-				expected: {
-					key_script: "Default Script",
-					key_html: "Default HTML"
-				}
-			},
-			{
-				name: "extracts keys from attributes",
-				source: `
-                    <script>
-						import { t } from "i18next";
-                    </script>
-					<button title={t('key_attr', 'Default Attr')}>
-					</button>
-				`,
-				path: "/en/translation.json",
-				expected: {
-					key_attr: "Default Attr"
-				}
-			},
-			{
-				// https://github.com/dreamscached/i18next-cli-plugin-svelte/issues/10
-				name: "handles typescript with interface",
-				source: `
-					<script lang="ts">
-						import { getTranslationContext } from './translation-context';
-
-						interface Props {
-							id: string;
-						}
-
-						const { t } = $derived.by(getTranslationContext('ui-form'));
-						const { id }: Props = $props();
-					</script>
-					<div {id}>
-						{t('hello-world', "Hello World!")}
-					</div>
-				`,
-				path: "/en/ui-form.json",
-				expected: {
-					"hello-world": "Hello World!"
-				}
-			}
-		])("$name", async ({ source, expected, path }) => {
-			await writeFile(join(tempDir, "src/App.svelte"), source);
-			const results = await extract(makeConfig());
-			const defaultFile = results.find((r) => pathEndsWith(r.path, path));
-			expect(defaultFile).toBeDefined();
-			expect(defaultFile!.newTranslations).toEqual(expected);
-		});
 	});
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { walk } from "estree-walker";
+import type * as estree from "estree";
 import type { Plugin, PluginContext } from "i18next-cli";
+import * as recast from "recast";
 import { parse, type AST } from "svelte/compiler";
+
+import { extractScriptStatements, extractTemplateStatements, toIIFE } from "./ast.js";
 
 /**
  * Enables I18next to extract translation keys from .svelte component files.
@@ -23,64 +26,31 @@ export class I18nextPluginSvelte implements Plugin {
 		// Passthrough for non-Svelte files
 		if (!path.match(/\.svelte$/)) return undefined;
 
-		const fromSvelteAst = (node: any) => code.slice(node.content.start, node.content.end);
-		const fromEstreeAst = (node: any) => {
-			switch (node.type) {
-				case "MustacheTag": // these have .expression
-				case "RawMustacheTag":
-				case "HtmlTag":
-				case "RenderTag":
-				case "AttachTag":
-				case "ConstTag":
-				case "IfBlock":
-				case "EachBlock":
-				case "KeyBlock":
-				case "AwaitBlock":
-					return `(${code.slice(node.expression.start, node.expression.end)})`;
-				case "SnippetBlock": // needs js-like tree handling
-					{
-						const js = fromNestedJs(node.parameters ?? []);
-						if (!js.length) return undefined;
-						return `(${js})`;
-					}
-				default:
-					return undefined;
-			}
+		const ast = parse(code, { filename: path }) as AST.Root & { html: AST.Fragment };
+
+		// Reassemble everything into a single async IIFE. Sharing one lexical
+		// scope mirrors how Svelte runs a component (the template and instance
+		// can see module-level declarations), which lets the extractor resolve
+		// scoped namespaces/keyPrefixes declared in <script> from usages in the
+		// template. The async wrapper also makes top-level `await import(...)`
+		// (rewritten from `import` statements) legal.
+		const body: estree.Statement[] = [];
+
+		// Order matters: declarations must precede the template usages that
+		// reference them. Module scope encloses instance scope encloses template.
+		if (ast.module) body.push(...extractScriptStatements(ast.module));
+		if (ast.instance) body.push(...extractScriptStatements(ast.instance));
+
+		// extract from HTML (mustache tags, svelte blocks, attribute exprs, snippets)
+		if ((ast.html as any)?.children?.length) body.push(...extractTemplateStatements(ast.html));
+
+		const program: estree.Program = {
+			type: "Program",
+			sourceType: "module",
+			body: [toIIFE(body)]
 		};
 
-		const fromNestedJs = (root: any) => {
-			const strings: string[] = [];
-			walk(root, {
-				enter(node: any) {
-					switch (node.type) {
-						case "AssignmentPattern":
-							strings.push(`(${code.slice(node.start, node.end)});`);
-							break;
-					}
-				}
-			});
-			return strings.join("\n;");
-		};
-
-		const ast = parse(code, { filename: path }) as AST.Root & { html: any };
-		const extracted: string[] = [];
-
-		// extract from the <script> tag
-		if (ast.instance) extracted.push(fromSvelteAst(ast.instance));
-		if (ast.module) extracted.push(fromSvelteAst(ast.module));
-
-		// extract from HTML
-		if (ast.html?.children?.length != 0) {
-			walk(ast.html, {
-				enter(node) {
-					const stmt = fromEstreeAst(node);
-					if (stmt) extracted.push(stmt);
-				}
-			});
-		}
-
-		// When contatenating make sure we don't cause issues with ASI
-		return extracted.join("\n;");
+		return recast.print(program).code;
 	}
 
 	/**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,6 +2222,7 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^10.0.1"
     "@trivago/prettier-plugin-sort-imports": "npm:^6.0.2"
+    "@types/estree": "npm:^1.0.8"
     "@types/node": "npm:^25.6.0"
     "@vitest/coverage-v8": "npm:4.1.5"
     eslint: "npm:^10.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1487,6 +1487,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ast-types@npm:^0.16.1":
+  version: 0.16.1
+  resolution: "ast-types@npm:0.16.1"
+  dependencies:
+    tslib: "npm:^2.0.1"
+  checksum: 10c0/abcc49e42eb921a7ebc013d5bec1154651fb6dbc3f497541d488859e681256901b2990b954d530ba0da4d0851271d484f7057d5eff5e07cb73e8b10909f711bf
+  languageName: node
+  linkType: hard
+
 "ast-v8-to-istanbul@npm:^1.0.0":
   version: 1.0.0
   resolution: "ast-v8-to-istanbul@npm:1.0.0"
@@ -1854,6 +1863,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esprima@npm:~4.0.0":
+  version: 4.0.1
+  resolution: "esprima@npm:4.0.1"
+  bin:
+    esparse: ./bin/esparse.js
+    esvalidate: ./bin/esvalidate.js
+  checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
+  languageName: node
+  linkType: hard
+
 "esquery@npm:^1.7.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
@@ -2210,6 +2229,7 @@ __metadata:
     i18next: "npm:^26.0.6"
     i18next-cli: "npm:^1.56.3"
     prettier: "npm:^3.8.3"
+    recast: "npm:^0.23.11"
     svelte: "npm:^5.55.4"
     typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.59.0"
@@ -3236,6 +3256,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"recast@npm:^0.23.11":
+  version: 0.23.11
+  resolution: "recast@npm:0.23.11"
+  dependencies:
+    ast-types: "npm:^0.16.1"
+    esprima: "npm:~4.0.0"
+    source-map: "npm:~0.6.1"
+    tiny-invariant: "npm:^1.3.3"
+    tslib: "npm:^2.0.1"
+  checksum: 10c0/45b520a8f0868a5a24ecde495be9de3c48e69a54295d82a7331106554b75cfba75d16c909959d056e9ceed47a1be5e061e2db8b9ecbcd6ba44c2f3ef9a47bd18
+  languageName: node
+  linkType: hard
+
 "restore-cursor@npm:^5.0.0":
   version: 5.1.0
   resolution: "restore-cursor@npm:5.1.0"
@@ -3417,6 +3450,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:~0.6.1":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^12.0.0":
   version: 12.0.0
   resolution: "ssri@npm:12.0.0"
@@ -3550,6 +3590,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-invariant@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "tiny-invariant@npm:1.3.3"
+  checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
+  languageName: node
+  linkType: hard
+
 "tinybench@npm:^2.9.0":
   version: 2.9.0
   resolution: "tinybench@npm:2.9.0"
@@ -3590,7 +3637,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.4.0":
+"tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62


### PR DESCRIPTION
Replaces the string-slicing extraction with proper AST manipulation, so i18next-cli sees real lexical scopes (as IIFE) instead of concatenated source snippets.