### PR TITLE
Add proper type definitions for AST node handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@swc/types": "^0.1.25",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/estree": "^1.0.8",
     "@types/node": "^25.6.0",

--- a/src/ast.test.ts
+++ b/src/ast.test.ts
@@ -161,36 +161,36 @@ describe("extractScriptIIFE", () => {
 		expect(js).toEqual(output);
 	});
 
-    it.each([
-        {
-            source: `
+	it.each([
+		{
+			source: `
                 {#snippet foobar()}
                 {/snippet}
             `,
-            output: `(async () => {
+			output: `(async () => {
     (async () => {})();
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 {#snippet foobar(x, y=42, z=fn("bar"))}
                 {/snippet}
             `,
-            output: `(async () => {
+			output: `(async () => {
     (async () => {
         fn("bar");
     })();
 })();`
-        },
-        {
-            source: `
+		},
+		{
+			source: `
                 {#snippet foobar(x, y=42, z=fn("bar"))}{/snippet}
                 {#snippet barbaz(x, y, z)}
                     <div my-attr={fn("bar")}>
                     </div>
                 {/snippet}
             `,
-            output: `(async () => {
+			output: `(async () => {
     (async () => {
         fn("bar");
     })();
@@ -199,11 +199,11 @@ describe("extractScriptIIFE", () => {
         fn("bar");
     })();
 })();`
-        }
-    ])("should convert snippet to iife", ({ source, output }) => {
-        const ast = parse(source) as AST.Root & { html: AST.Fragment };
+		}
+	])("should convert snippet to iife", ({ source, output }) => {
+		const ast = parse(source) as AST.Root & { html: AST.Fragment };
 		const iife = extractTemplateIIFE(ast.html);
 		const js = recast.print(iife).code;
 		expect(js).toEqual(output);
-    });
+	});
 });

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,18 +1,38 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type * as estree from "estree";
 import { walk } from "estree-walker";
 import { type AST } from "svelte/compiler";
 
 /**
+ * Minimal shape of the (legacy) Svelte template nodes we read a JS expression
+ * from. `parse()` returns the legacy AST, but Svelte 5 only ships types for its
+ * modern AST, so we describe the handful of fields we actually touch ourselves.
+ */
+interface SvelteExpressionNode {
+	type:
+		| "MustacheTag"
+		| "RawMustacheTag"
+		| "HtmlTag"
+		| "RenderTag"
+		| "AttachTag"
+		| "ConstTag"
+		| "IfBlock"
+		| "EachBlock"
+		| "KeyBlock"
+		| "AwaitBlock";
+	expression: estree.Expression;
+}
+
+/**
  * Rewrites a Svelte `<script>` AST into IIFE-safe statements: top-level
  * `import`/`export`/`import.meta` constructs are converted to forms that are
- * legal inside a function body. The returned statements are *not* wrapped — use
+ * legal inside a function body. The returned statements are *not* wrapped - use
  * {@link toIIFE} (or {@link extractScriptIIFE}) to do that.
  */
 export function extractScriptStatements(script: AST.Script): estree.Statement[] {
-	// We can't have top-level 'import ...' declaration in IIFE, so we
-	// need to convert them to 'const {} = await import' first.
-	walk(script as any, {
+	// `script.content` is an estree `Program`, so the walk is fully typed. We
+	// can't have top-level 'import ...' declarations in an IIFE, so we convert
+	// them to 'const {} = await import' (and strip exports) first.
+	walk(script.content, {
 		enter(node) {
 			switch (node.type) {
 				case "ImportDeclaration":
@@ -29,6 +49,8 @@ export function extractScriptStatements(script: AST.Script): estree.Statement[] 
 		}
 	});
 
+	// Imports/exports have been rewritten into statements above, so the body no
+	// longer contains ModuleDeclarations despite what the static type says.
 	return script.content.body as unknown as estree.Statement[];
 }
 
@@ -40,10 +62,12 @@ export function extractScriptStatements(script: AST.Script): estree.Statement[] 
 export function extractTemplateStatements(fragment: AST.Fragment): estree.ExpressionStatement[] {
 	const statements: estree.ExpressionStatement[] = [];
 
-	walk(fragment as any, {
-		// @ts-expect-error we're walking Svelte AST here
-		enter(node: AST.BaseNode) {
-			switch (node.type) {
+	// estree-walker is typed for estree, but the Svelte template tree is happily
+	// walkable all the same; we narrow each node to the legacy shapes we read.
+	walk(fragment as unknown as estree.Node, {
+		enter(node) {
+			const svelteNode = node as unknown as SvelteExpressionNode | AST.SnippetBlock;
+			switch (svelteNode.type) {
 				case "MustacheTag":
 				case "RawMustacheTag":
 				case "HtmlTag":
@@ -56,11 +80,11 @@ export function extractTemplateStatements(fragment: AST.Fragment): estree.Expres
 				case "AwaitBlock":
 					statements.push({
 						type: "ExpressionStatement",
-						expression: (node as any).expression
+						expression: svelteNode.expression
 					});
 					break;
 				case "SnippetBlock":
-					statements.push(transformSnippet(node as AST.SnippetBlock));
+					statements.push(transformSnippet(svelteNode));
 					this.remove();
 					break;
 			}
@@ -81,14 +105,12 @@ export function extractTemplateExpr(fragment: AST.Fragment): estree.ExpressionSt
 function transformImport(
 	node: estree.ImportDeclaration
 ): estree.VariableDeclaration | estree.ExpressionStatement {
-	// 'await' expression common for any imports
+	// 'await import(...)' expression common for any imports
 	const awaitExpression: estree.AwaitExpression = {
 		type: "AwaitExpression",
 		argument: {
-			type: "CallExpression",
-			callee: { type: "Import" as any },
-			arguments: [node.source],
-			optional: false
+			type: "ImportExpression",
+			source: node.source
 		}
 	};
 
@@ -233,15 +255,16 @@ function transformImportMeta(node: estree.Node): estree.Node {
 function transformSnippet(snippet: AST.SnippetBlock): estree.ExpressionStatement {
 	const statements: estree.Statement[] = [];
 
-	walk(snippet as any, {
+	// Collect any call expressions inside the snippet (parameter defaults and
+	// body) - that's where translation calls live. The CallExpression nodes are
+	// estree-shaped, so the walk is typed once we cross the Svelte boundary.
+	walk(snippet as unknown as estree.Node, {
 		enter(node) {
-			switch (node.type) {
-				case "CallExpression":
-					statements.push({
-						type: "ExpressionStatement",
-						expression: node
-					});
-					break;
+			if (node.type === "CallExpression") {
+				statements.push({
+					type: "ExpressionStatement",
+					expression: node
+				});
 			}
 		}
 	});

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -27,7 +27,10 @@ describe("I18nextSveltePlugin", () => {
 		it.each([
 			{ name: "an example component", source: "<script>console.log('test')</script>" },
 			{ name: "an empty file", source: "" },
-			{ name: "a file with no <script> tag", source: "<div>foobar</div><style>div{}</style>" },
+			{
+				name: "a file with no <script> tag",
+				source: "<div>foobar</div><style>div{}</style>"
+			},
 			{ name: "an empty <script> tag", source: "<script></script>" },
 			{ name: "an empty <script module> tag", source: "<script module></script>" },
 			{

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,10 +1,24 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { CallExpression, Expression, VariableDeclarator } from "@swc/types";
 import type * as estree from "estree";
 import type { Plugin, PluginContext } from "i18next-cli";
 import * as recast from "recast";
 import { parse, type AST } from "svelte/compiler";
 
 import { extractScriptStatements, extractTemplateStatements, toIIFE } from "./ast.js";
+
+/**
+ * The node type passed to {@link Plugin.onVisitNode}. i18next-cli walks an
+ * `@swc/core` AST; deriving the type from the plugin interface keeps our public
+ * surface in sync with it without pinning a specific `@swc` version here.
+ */
+type VisitorNode = Parameters<NonNullable<Plugin["onVisitNode"]>>[0];
+
+/**
+ * Svelte's `parse()` returns the *legacy* AST, whose root exposes `html` (a
+ * fragment with `children`) instead of the modern `fragment`/`nodes`. Svelte 5
+ * only ships types for the modern AST, so we describe the legacy bits we use.
+ */
+type LegacyRoot = AST.Root & { html: AST.Fragment & { children: unknown[] } };
 
 /**
  * Enables I18next to extract translation keys from .svelte component files.
@@ -26,7 +40,7 @@ export class I18nextPluginSvelte implements Plugin {
 		// Passthrough for non-Svelte files
 		if (!path.match(/\.svelte$/)) return undefined;
 
-		const ast = parse(code, { filename: path }) as AST.Root & { html: AST.Fragment };
+		const ast = parse(code, { filename: path }) as unknown as LegacyRoot;
 
 		// Reassemble everything into a single async IIFE. Sharing one lexical
 		// scope mirrors how Svelte runs a component (the template and instance
@@ -42,7 +56,7 @@ export class I18nextPluginSvelte implements Plugin {
 		if (ast.instance) body.push(...extractScriptStatements(ast.instance));
 
 		// extract from HTML (mustache tags, svelte blocks, attribute exprs, snippets)
-		if ((ast.html as any)?.children?.length) body.push(...extractTemplateStatements(ast.html));
+		if (ast.html.children.length) body.push(...extractTemplateStatements(ast.html));
 
 		const program: estree.Program = {
 			type: "Program",
@@ -61,41 +75,22 @@ export class I18nextPluginSvelte implements Plugin {
 	 * @see https://github.com/dreamscached/i18next-cli-plugin-svelte/issues/5
 	 * @see https://github.com/i18next/i18next-cli/issues/231
 	 */
-	onVisitNode(node: any, context: PluginContext): void {
-		switch (node.type) {
-			case "VariableDeclarator":
-				this.handleDerivedBy(node, context);
-				break;
+	onVisitNode(node: VisitorNode, context: PluginContext): void {
+		if (node.type === "VariableDeclarator") {
+			this.handleDerivedBy(node as VariableDeclarator, context);
 		}
 	}
 
-	private handleDerivedBy(node: any, context: PluginContext) {
+	private handleDerivedBy(node: VariableDeclarator, context: PluginContext): void {
 		const init = node.init;
 		if (!init || init.type !== "CallExpression") return;
 
-		// Detect $derived.by(<inner>) or $derived(<inner>)
-		const callee = init.callee;
-		let innerCall: any;
-		if (
-			callee.type === "MemberExpression" &&
-			callee.object.type === "Identifier" &&
-			callee.object.value === "$derived" &&
-			callee.property.type === "Identifier" &&
-			callee.property.value === "by"
-		) {
-			const firstArg = init.arguments?.[0]?.expression;
-			if (firstArg?.type === "CallExpression") innerCall = firstArg;
-		} else if (callee.type === "Identifier" && callee.value === "$derived") {
-			const firstArg = init.arguments?.[0]?.expression;
-			if (firstArg?.type === "CallExpression") innerCall = firstArg;
-		}
+		const innerCall = unwrapDerived(init);
+		if (!innerCall || innerCall.callee.type !== "Identifier") return;
 
-		if (!innerCall || innerCall.callee?.type !== "Identifier") return;
-
-		const hookName: string = innerCall.callee.value;
+		const hookName = innerCall.callee.value;
 
 		// Check if the inner call matches a registered useTranslationNames entry
-		// prettier-ignore
 		const useTranslationNames = context.config.extract.useTranslationNames;
 		if (!useTranslationNames) return;
 
@@ -118,32 +113,12 @@ export class I18nextPluginSvelte implements Plugin {
 
 		if (!matched) return;
 
-		const getDefaultNsNode = (node: any) => {
-			switch (node?.type) {
-				case "StringLiteral":
-					return node.value;
-				case "ArrayExpression":
-					return (() => {
-						const expressions = node.elements.map((it: any) => it.expression);
-						// prettier-ignore
-						const isStringArray = expressions.every((it: any) => it.type === "StringLiteral");
-						if (!isStringArray) return undefined;
-						return expressions[0]?.value ?? undefined;
-					})();
-				default:
-					return undefined;
-			}
-		};
-
 		// Extract namespace and keyPrefix from the inner call's arguments
-		const nsNode =
-			nsArgIndex !== -1 ? innerCall.arguments?.[nsArgIndex]?.expression : undefined;
-		const kpNode =
-			kpArgIndex !== -1 ? innerCall.arguments?.[kpArgIndex]?.expression : undefined;
+		const nsNode = nsArgIndex !== -1 ? innerCall.arguments[nsArgIndex]?.expression : undefined;
+		const kpNode = kpArgIndex !== -1 ? innerCall.arguments[kpArgIndex]?.expression : undefined;
 
-		const defaultNs: string | undefined = getDefaultNsNode(nsNode);
-		const keyPrefix: string | undefined =
-			kpNode?.type === "StringLiteral" ? kpNode.value : undefined;
+		const defaultNs = resolveNamespace(nsNode);
+		const keyPrefix = kpNode?.type === "StringLiteral" ? kpNode.value : undefined;
 
 		if (!defaultNs && !keyPrefix) return;
 
@@ -157,10 +132,9 @@ export class I18nextPluginSvelte implements Plugin {
 		// Register destructured variables in scope
 		if (node.id.type === "ObjectPattern") {
 			for (const prop of node.id.properties) {
-				if (prop.type === "AssignmentPatternProperty" && prop.key.type === "Identifier") {
+				if (prop.type === "AssignmentPatternProperty") {
 					context.setVarInScope(prop.key.value, scopeInfo);
-				}
-				if (prop.type === "KeyValuePatternProperty" && prop.value.type === "Identifier") {
+				} else if (prop.type === "KeyValuePatternProperty" && prop.value.type === "Identifier") {
 					context.setVarInScope(prop.value.value, scopeInfo);
 				}
 			}
@@ -169,4 +143,42 @@ export class I18nextPluginSvelte implements Plugin {
 			context.setVarInScope(node.id.value, scopeInfo);
 		}
 	}
+}
+
+/**
+ * Unwraps a `$derived(<inner>)` or `$derived.by(<inner>)` call, returning the
+ * inner call expression (e.g. `useTranslation(...)`) when present.
+ */
+function unwrapDerived(init: CallExpression): CallExpression | undefined {
+	const callee = init.callee;
+
+	const isDerived =
+		(callee.type === "Identifier" && callee.value === "$derived") ||
+		(callee.type === "MemberExpression" &&
+			callee.object.type === "Identifier" &&
+			callee.object.value === "$derived" &&
+			callee.property.type === "Identifier" &&
+			callee.property.value === "by");
+
+	if (!isDerived) return undefined;
+
+	const firstArg = init.arguments[0]?.expression;
+	return firstArg?.type === "CallExpression" ? firstArg : undefined;
+}
+
+/**
+ * Resolves a namespace argument to its string value. Accepts a plain string
+ * literal or an array of string literals (fallback namespaces), in which case
+ * the first entry wins.
+ *
+ * @see https://github.com/dreamscached/i18next-cli-plugin-svelte/issues/15
+ */
+function resolveNamespace(node: Expression | undefined): string | undefined {
+	if (node?.type === "StringLiteral") return node.value;
+	if (node?.type !== "ArrayExpression") return undefined;
+
+	const elements = node.elements.map((it) => it?.expression);
+	const first = elements[0];
+	const allStrings = elements.every((it) => it?.type === "StringLiteral");
+	return allStrings && first?.type === "StringLiteral" ? first.value : undefined;
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -134,7 +134,10 @@ export class I18nextPluginSvelte implements Plugin {
 			for (const prop of node.id.properties) {
 				if (prop.type === "AssignmentPatternProperty") {
 					context.setVarInScope(prop.key.value, scopeInfo);
-				} else if (prop.type === "KeyValuePatternProperty" && prop.value.type === "Identifier") {
+				} else if (
+					prop.type === "KeyValuePatternProperty" &&
+					prop.value.type === "Identifier"
+				) {
 					context.setVarInScope(prop.value.value, scopeInfo);
 				}
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,6 +2221,7 @@ __metadata:
   resolution: "i18next-cli-plugin-svelte@workspace:."
   dependencies:
     "@eslint/js": "npm:^10.0.1"
+    "@swc/types": "npm:^0.1.25"
     "@trivago/prettier-plugin-sort-imports": "npm:^6.0.2"
     "@types/estree": "npm:^1.0.8"
     "@types/node": "npm:^25.6.0"


### PR DESCRIPTION
Replaces `any` in the AST node-handling logic with precise types, removing `eslint-disable no-explicit-any` comments.
